### PR TITLE
EDJ Metric

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/EDJMetric.java
+++ b/java-frontend/src/main/java/org/sonar/java/EDJMetric.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java;
+
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.measures.Metrics;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class EDJMetric implements Metrics {
+
+    public static final Metric<Integer> EDJ_METRIC = new Metric.Builder("edj_metric", "EDJ Metric", Metric.ValueType.INT)
+            .setDescription("Ratio of assertions in unit tests")
+            .setDirection(Metric.DIRECTION_BETTER)
+            .setQualitative(false)
+            .setDomain(CoreMetrics.DOMAIN_GENERAL)
+            .create();
+
+    @Override
+    public List<Metric> getMetrics() {
+        return asList(EDJ_METRIC);
+    }
+}

--- a/java-frontend/src/main/java/org/sonar/java/Measurer.java
+++ b/java-frontend/src/main/java/org/sonar/java/Measurer.java
@@ -30,16 +30,13 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Metric;
-import org.sonar.java.ast.visitors.CognitiveComplexityVisitor;
-import org.sonar.java.ast.visitors.CommentLinesVisitor;
-import org.sonar.java.ast.visitors.LinesOfCodeVisitor;
-import org.sonar.java.ast.visitors.StatementVisitor;
-import org.sonar.java.ast.visitors.SubscriptionVisitor;
+import org.sonar.java.ast.visitors.*;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import static org.sonar.java.EDJMetric.EDJ_METRIC;
 
 public class Measurer extends SubscriptionVisitor {
 
@@ -92,6 +89,7 @@ public class Measurer extends SubscriptionVisitor {
     saveMetricOnFile(CoreMetrics.COMMENT_LINES, commentLinesVisitor.commentLinesMetric());
     saveMetricOnFile(CoreMetrics.STATEMENTS, new StatementVisitor().numberOfStatements(context.getTree()));
     saveMetricOnFile(CoreMetrics.NCLOC, new LinesOfCodeVisitor().linesOfCode(context.getTree()));
+    saveMetricOnFile(EDJ_METRIC, new EDJVisitor().compilationUnitComplexity(context.getTree()));
 
     saveMetricOnFile(CoreMetrics.COGNITIVE_COMPLEXITY, CognitiveComplexityVisitor.compilationUnitComplexity(context.getTree()));
   }

--- a/java-frontend/src/main/java/org/sonar/java/ast/visitors/EDJVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/ast/visitors/EDJVisitor.java
@@ -1,0 +1,32 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.ast.visitors;
+
+import org.sonar.plugins.java.api.tree.*;
+
+public class EDJVisitor extends BaseTreeVisitor {
+    public EDJVisitor() {
+    }
+
+    public static int compilationUnitComplexity(CompilationUnitTree cut) {
+        // ADD YOUR CODE
+        return 10;
+    }
+}

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaPlugin.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaPlugin.java
@@ -26,14 +26,7 @@ import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.utils.Version;
-import org.sonar.java.AnalysisWarningsWrapper;
-import org.sonar.java.DefaultJavaResourceLocator;
-import org.sonar.java.JavaClasspath;
-import org.sonar.java.JavaClasspathProperties;
-import org.sonar.java.JavaConstants;
-import org.sonar.java.JavaSonarLintClasspath;
-import org.sonar.java.JavaTestClasspath;
-import org.sonar.java.SonarComponents;
+import org.sonar.java.*;
 import org.sonar.java.filters.PostAnalysisIssueFilter;
 import org.sonar.plugins.jacoco.JaCoCoExtensions;
 import org.sonar.plugins.surefire.SurefireExtensions;
@@ -94,6 +87,7 @@ public class JavaPlugin implements Plugin {
     }
 
     context.addExtensions(builder.build());
+    context.addExtension(EDJMetric.class);
   }
 
   /**


### PR DESCRIPTION
This PR introduces the bare bones of a new metric called "EDJ Metric" that is implemented in the EDJVisitor.java (as an extension of the BaseTreeVisitor). Currently, this metric is set to 10 on every Java file. The implementation of the metric logic goes into https://github.com/mcnallyj1037/edj-sonar-java-plugin/compare/sonar-java-5.13.1.18282...new-measure?expand=1#diff-868187c6464d4c96a367ee7f78b4766997c7cd0cdef46af6a66f836ea628860fR28. If you get stuck in the implementation of the visitor, check for example how it is done in the [CognitiveComplexityVisitor](https://github.com/mcnallyj1037/edj-sonar-java-plugin/blob/new-measure/java-frontend/src/main/java/org/sonar/java/ast/visitors/CognitiveComplexityVisitor.java). 

To produce the jar of the new sonar-java plugin run `mvn clean install -DskipTests`. 

This jar was added to the plugins directory (and replaced the `sonar-java-plugin-5.13.1.18282.jar`) in SonarQube 7.9.5. 

This measure shows up in SonarQube as a General measure. Note that you'll need to select a file to see it or by appending the `&metric=edj_metric` to your URL in the measures page. Here's an example screenshot of the rule (I've deleted sensitive information of where this plugin is executed).

![Screenshot 2021-03-08 at 11 05 45](https://user-images.githubusercontent.com/601882/110314292-9057e700-7fff-11eb-9620-3b5b679d21f0.png)
 